### PR TITLE
Reduce payload

### DIFF
--- a/custom_components/trmnl_sensor_push/__init__.py
+++ b/custom_components/trmnl_sensor_push/__init__.py
@@ -24,11 +24,9 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 def create_entity_payload(state) -> dict:
     """Create the payload for a single entity."""
     payload = {
-        "name": state.attributes.get('friendly_name', state.entity_id),
         "state": state.state,
         "device_class": state.attributes.get('device_class', None),
         "unit_of_measurement": state.attributes.get('unit_of_measurement', None),
-        "icon": state.attributes.get('icon', None),
         "friendly_name": state.attributes.get('friendly_name', state.entity_id)
     }
     _LOGGER.debug("TRMNL: Created payload for %s: %s", state.entity_id, payload)

--- a/custom_components/trmnl_sensor_push/__init__.py
+++ b/custom_components/trmnl_sensor_push/__init__.py
@@ -25,12 +25,11 @@ def create_entity_payload(state) -> dict:
     """Create the payload for a single entity."""
     payload = {
         "name": state.attributes.get('friendly_name', state.entity_id),
-        "value": state.state,
+        "state": state.state,
         "device_class": state.attributes.get('device_class', None),
         "unit_of_measurement": state.attributes.get('unit_of_measurement', None),
         "icon": state.attributes.get('icon', None),
-        "friendly_name": state.attributes.get('friendly_name', state.entity_id),
-        "attributes": state.attributes
+        "friendly_name": state.attributes.get('friendly_name', state.entity_id)
     }
     _LOGGER.debug("TRMNL: Created payload for %s: %s", state.entity_id, payload)
     return payload


### PR DESCRIPTION
First of all: Thanks a lot for this component. This was exactly what I was looking for 🔝 

With the recent changes for webhooks TRMNL reduced the possible payload of private plugins to 2kb. I noticed that with the addition of "attributes" in the payload I only was able to send 5 sensors. With the removal of the attributes-collection also 6 sensors are not a problem anymore.